### PR TITLE
GITHUB_TOKEN is Enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,4 @@ jobs:
           artifacts: "build/app/outputs/apk/release/*,build/ios/iphoneos/app.ipa"
           tag: v1.0.${{ github.run_number }}
           token: ${{ secrets.TOKEN }}
+


### PR DESCRIPTION
1.Repository Settings → Actions → General.2.Under Workflow permissions, ensure that:2.1 Read and write permissions is selected.
 2.2 Allow GitHub Actions to create and approve pull requests is enabled if required. created new token Settings → Secrets and variables → Actions.

Step 1: Generate a GitHub Personal Access Token (PAT)
If you want to use your own token (instead of the default GITHUB_TOKEN), you'll need to generate a Personal Access Token (PAT).

Go to GitHub:
Visit [GitHub Tokens](https://github.com/settings/tokens).
Generate a new token:
Click Generate new token.
Give the token a name (e.g., ci-cd-token).
Select the necessary scopes for the token. At a minimum, select:
repo (Full control of private repositories)
workflow (Update GitHub Actions workflows)
Click Generate token.
Copy the generated token.
Step 2: Add the Token to GitHub Secrets
Go to your repository on GitHub.
Navigate to Settings → Secrets and variables → Actions.
Click on New repository secret.
Name the secret as TOKEN (or any other name that you want to reference in your workflow).
Paste the token you copied in the Value field.
Click Add secret.
Step 3: Update the GitHub Actions Workflow
If you want to use the secret TOKEN you just created, update your GitHub Actions workflow like this:

yaml
Copy code
- name: Push to Releases
  uses: ncipollo/release-action@v1
  with:
    artifacts: "build/app/outputs/apk/release/*,build/ios/iphoneos/app.ipa"
    tag: v1.0.${{ github.run_number }}
    token: ${{ secrets.TOKEN }}  # This is the secret you added